### PR TITLE
Improve handling of nested type parameters

### DIFF
--- a/src/LightSumTypes.jl
+++ b/src/LightSumTypes.jl
@@ -52,7 +52,6 @@ function sumtype_expr(typedef)
     variants_with_P = filter(has_typevars(typeparams), variants)
     variants_bounded = unique([v in variants_with_P ? namify(v) : v for v in variants])
 
-    check_if_typeof(v) = v isa Expr && v.head == :call && v.args[1] == :typeof
     variants_names = namify.([check_if_typeof(v) ? v.args[2] : v for v in variants])
     for vname in unique(variants_names)
         inds = findall(==(vname), variants_names)
@@ -129,6 +128,8 @@ end
 has_typevars(expr::Symbol, typevars) = expr in typevars
 has_typevars(expr, typevars) = Meta.isexpr(expr, :curly) && any(e -> has_typevars(e, typevars), expr.args)
 has_typevars(typevars) = Base.Fix2(has_typevars, typevars)
+
+check_if_typeof(v) = v isa Expr && v.head == :call && v.args[1] == :typeof
 
 """
     variant(inst)

--- a/src/LightSumTypes.jl
+++ b/src/LightSumTypes.jl
@@ -49,7 +49,7 @@ function sumtype_expr(typedef)
     typeparams = type isa Symbol ? [] : type.args[2:end]
     variants = type_with_variants.args[2:end]
     !allunique(variants) && error("Duplicated variants in sumtype")
-    variants_with_P = [v for v in variants if has_typevars(v, typeparams)]
+    variants_with_P = filter(has_typevars(typeparams), variants)
     variants_bounded = unique([v in variants_with_P ? namify(v) : v for v in variants])
 
     check_if_typeof(v) = v isa Expr && v.head == :call && v.args[1] == :typeof
@@ -128,6 +128,7 @@ end
 
 has_typevars(expr::Symbol, typevars) = expr in typevars
 has_typevars(expr, typevars) = Meta.isexpr(expr, :curly) && any(e -> has_typevars(e, typevars), expr.args)
+has_typevars(typevars) = Base.Fix2(has_typevars, typevars)
 
 """
     variant(inst)

--- a/test/sumtype_macro_tests.jl
+++ b/test/sumtype_macro_tests.jl
@@ -6,27 +6,27 @@ struct ST1 end
 Base.copy(x::ST1) = ST1()
 
 @kwdef mutable struct F{X<:Integer}
-    a::Tuple{X, X}
-    b::Tuple{Float64, Float64}
+    a::Tuple{X,X}
+    b::Tuple{Float64,Float64}
     const c::Symbol
 end
 
 @kwdef mutable struct G{X}
-    a::Tuple{X, X}
+    a::Tuple{X,X}
     d::Int
     e::Int
     const c::Symbol
 end
 
 @kwdef mutable struct H{X,Y<:Real}
-    a::Tuple{X, X}
+    a::Tuple{X,X}
     f::Y
-    g::Tuple{Complex, Complex}
+    g::Tuple{Complex,Complex}
     const c::Symbol
 end
 
 abstract type AbstractE end
-@sumtype E(F,G,H) <: AbstractE
+@sumtype E(F, G, H) <: AbstractE
 @sumtype FF(F{Int32}, F{Int64})
 
 @kwdef mutable struct Wolf{T,N}
@@ -58,7 +58,7 @@ end
 @sumtype Simple(SimpleA, SimpleB) <: AbstractSimple
 
 struct Some{T}
-   val::T
+    val::T
 end
 
 struct None end
@@ -67,25 +67,27 @@ struct None end
 
 @sumtype Nested{T}(Vector{T}, Vector{Vector{T}})
 
+@sumtype Recursive(Symbol, Recursive)
+
 @testset "@sumtype" begin
-    
+
     st = SingleT1(ST1())
     @test propertynames(st) == ()
     @test copy(st) == st
 
-    f = E(F((1,1), (1.0, 1.0), :s))
-    g1 = E(G((1,1), 1, 1, :c))
-    g2 = E(G(; a = (1,1), d = 1, e = 1, c = :c))
-    g3 = (E∘G)((1,1), 1, 1, :c)
-    g4 = (E∘G)(; a = (1,1), d = 1, e = 1, c = :c)
-    h = E(H((1,1), 1, (im, im), :j))
+    f = E(F((1, 1), (1.0, 1.0), :s))
+    g1 = E(G((1, 1), 1, 1, :c))
+    g2 = E(G(; a=(1, 1), d=1, e=1, c=:c))
+    g3 = (E ∘ G)((1, 1), 1, 1, :c)
+    g4 = (E ∘ G)(; a=(1, 1), d=1, e=1, c=:c)
+    h = E(H((1, 1), 1, (im, im), :j))
 
     @test_throws "" eval(:(@sumtype Z.E))
-    @test_throws "" E(F((1.0,1.0), (1.0, 1.0), :s))
-    @test_throws "" E(G((1,1), im, (im, im), :d))
-    @test_throws "" E(G((im,im), 1, (im, im), :d))
+    @test_throws "" E(F((1.0, 1.0), (1.0, 1.0), :s))
+    @test_throws "" E(G((1, 1), im, (im, im), :d))
+    @test_throws "" E(G((im, im), 1, (im, im), :d))
 
-    @test f.a == (1,1)
+    @test f.a == (1, 1)
     @test f.b == (1.0, 1.0)
     @test f.c == :s
     @test g1.d === g2.d === 1
@@ -95,25 +97,25 @@ struct None end
     @test is_sumtype(typeof(g1)) == true
     @test is_sumtype(G) == false
     @test variantof(g1) == G{Int}
-    
+
     f.a = (3, 3)
     @test f.a == (3, 3)
 
     @test variant(f) isa F
     @test propertynames(f) == (:a, :b, :c)
 
-    @test allvariants(E) == allvariants(typeof(f)) == (F = F, G = G, H = H)
+    @test allvariants(E) == allvariants(typeof(f)) == (F=F, G=G, H=H)
 
-    ff1 = FF(F((1,1), (1.0, 1.0), :s))
-    ff2 = FF(F((Int32(1),Int32(1)), (1.0, 1.0), :s))
-    @test allvariants(FF) == (F_Int32 = F{Int32}, F_Int64 = F{Int64})
+    ff1 = FF(F((1, 1), (1.0, 1.0), :s))
+    ff2 = FF(F((Int32(1), Int32(1)), (1.0, 1.0), :s))
+    @test allvariants(FF) == (F_Int32=F{Int32}, F_Int64=F{Int64})
 
     hawk_1 = Animal(Hawk(1.0, 2.0, 3))
-    hawk_2 = Animal(Hawk(; ground_speed = 2.3, flight_speed = 2))
+    hawk_2 = Animal(Hawk(; ground_speed=2.3, flight_speed=2))
     wolf_1 = Animal(Wolf(2.0, 3.0, :black))
-    wolf_2 = Animal(Wolf(; ground_speed = 2.0, fur_color = :white))
-    wolf_3 = Animal(Wolf{Int, Float64}(2.0, 3.0, :black))
-    wolf_4 = Animal(Wolf{Float64, Float64}(; ground_speed = 2.0, fur_color = :white))
+    wolf_2 = Animal(Wolf(; ground_speed=2.0, fur_color=:white))
+    wolf_3 = Animal(Wolf{Int,Float64}(2.0, 3.0, :black))
+    wolf_4 = Animal(Wolf{Float64,Float64}(; ground_speed=2.0, fur_color=:white))
 
     @test hawk_1.energy == 1.0
     @test hawk_2.energy == 0.1
@@ -128,7 +130,7 @@ struct None end
     @test_throws "" wolf_1.flight_speed
     @test variant(hawk_1) isa Hawk
     @test variant(wolf_1) isa Wolf
-    @test allvariants(Animal) == allvariants(typeof(wolf_3)) == (Wolf = Wolf, Hawk = Hawk)
+    @test allvariants(Animal) == allvariants(typeof(wolf_3)) == (Wolf=Wolf, Hawk=Hawk)
 
     b = Simple(SimpleA(1, 3))
     c = Simple(SimpleB(2, "a"))
@@ -143,24 +145,33 @@ struct None end
     @test variant(c) isa SimpleB
     @test Simple <: AbstractSimple
     @test b isa Simple && c isa Simple
-    @test allvariants(Simple) == allvariants(typeof(b)) == (SimpleA = SimpleA, SimpleB = SimpleB)
+    @test allvariants(Simple) == allvariants(typeof(b)) == (SimpleA=SimpleA, SimpleB=SimpleB)
 
     option_none = Option{Int}(None())
-    option_none2 = (Option{Int}∘None)()
+    option_none2 = (Option{Int} ∘ None)()
     option_some = Option(Some(1))
     option_some2 = Option{Int}(Some(1))
-    option_some3 = (Option{Int}∘Some)(1)
-    option_some4 = (Option∘Some)(1)
+    option_some3 = (Option{Int} ∘ Some)(1)
+    option_some4 = (Option ∘ Some)(1)
     @test variant(option_none) isa None
     @test variant(option_some) isa Some{Int}
     @test variant(option_some2) isa Some{Int}
     @test variant(option_some3) isa Some{Int}
     @test variant(option_some4) isa Some{Int}
-    @test allvariants(Option) == (None = None, Some = Some)
+    @test allvariants(Option) == (None=None, Some=Some)
     @test option_some.val == 1
 
     v = Nested([1, 2, 3])
     v_nested = Nested{Int}([[1, 2], [3, 4]]) # Nested([[1, 2], [3, 4]]) yields Nested{Vector{Int}}
     @test variant(v) isa Vector{Int}
     @test variant(v_nested) isa Vector{Vector{Int}}
+
+    r = Recursive(:val)
+    r_recursive = Recursive(r)
+    r_rerecursive = Recursive(r_recursive)
+
+    @test variant(r) == :val
+    @test variant(r_recursive) == r
+    @test variant(r_rerecursive) == r_recursive
+
 end

--- a/test/sumtype_macro_tests.jl
+++ b/test/sumtype_macro_tests.jl
@@ -65,6 +65,8 @@ struct None end
 
 @sumtype Option{T}(None, Some{T})
 
+@sumtype Nested{T}(Vector{T}, Vector{Vector{T}})
+
 @testset "@sumtype" begin
     
     st = SingleT1(ST1())
@@ -156,4 +158,9 @@ struct None end
     @test variant(option_some4) isa Some{Int}
     @test allvariants(Option) == (None = None, Some = Some)
     @test option_some.val == 1
+
+    v = Nested([1, 2, 3])
+    v_nested = Nested{Int}([[1, 2], [3, 4]]) # Nested([[1, 2], [3, 4]]) yields Nested{Vector{Int}}
+    @test variant(v) isa Vector{Int}
+    @test variant(v_nested) isa Vector{Vector{Int}}
 end


### PR DESCRIPTION
I've adapted some of the code to try and catch some more edge cases with weird type parameters.

In the following example, `A` and `B` would have been fine, but the macro failed to detect `C{B{T}}` has a type parameter.
```julia
@sumtype MySumType{T}(A,B{T},C{B{T}})
```
While it is possible to work around this by defining type aliases, here I've simply introduced `has_typevars` to work recursively, so these cases should be correctly handled now.
Importantly though, I have no safeguard against infinite recursion, which you may or may not want?

Then, I've slightly refactored the `branchs` function to:
1. build a nested `if` expression instead of a linear one. This does not alter functionality, but was easier to debug since `@macroexpand` then actually prints parse-able code:

```julia
# previously printed as: (cannot copy-paste code, but expression is evaluated correctly)
if v isa F
    return 1
end
elseif v isa G
    return 2
end
elseif v isa H
    return 3
end
error("THIS_SHOULD_BE_UNREACHABLE")

# now:
if v isa F
    return 1
elseif v isa G
    return 2
elseif v isa H
    return 3
else
    error("THIS_SHOULD_BE_UNREACHABLE")
end
```

2. Added `where` clauses in the function definitions, therefore no longer needing to `namify` the variant types.

I tried adding some small tests, and it seems now nested type variables and recursive sumtypes both work, but I have a hard time gauging what the implications of these changes are for other people.

This fixes #115 .

---

Some small comments that are possibly interesting/might need changes:

The `allvariants` function does not handle nested type parameters very well:
```julia
@sumtype Nested{T}(Vector{T}, Vector{Vector{T}})
julia> allvariants(Nested)
(Vector_T = Vector, var"Vector_Vector{T}" = Vector)
```
Here, both the names of the named tuple as well as the values aren't great. In principle for the names it is again possible to have a recursive definition with `Vector_Vector_T`, but that still does not really solve the problem completely: `A{B{D,E},C}` and `A{B,D,E,C}` would still be indistinguishable.

Also the following does not work:
```julia
julia> allvariants(Nested{Int})
ERROR: MethodError: no method matching allvariants(::Type{Nested{Int64}})
The function `allvariants` exists, but no method is defined for this combination of argument types.
```
I am not too bothered by these things, since I don't think I would need `allvariants` at all, but I did want to bring this up in case this matters for some specific purposes. If this turns out to be important, I can look into improving that. (This is not something that is caused by this PR afaik, and was already present before)